### PR TITLE
Update MNIST example with proper cluster

### DIFF
--- a/docs/start/experiment.md
+++ b/docs/start/experiment.md
@@ -6,7 +6,7 @@ Don't worry if you don't know about Python, Pytorch, or MNIST data; you won't ne
 
 ## Experiments on Beaker.org
 
-First, go to the [MNIST example](https://beaker.org/ex/ex_zvtqxr5dlpqe) page on Beaker.org. (Sign in if you haven't already.)
+First, go to the [MNIST example](https://beaker.org/ex/ex_z550sk9sz1ob) page on Beaker.org. (Sign in if you haven't already.)
 
 ![Beaker page for MNIST example](../images/beaker_ex.png)
 
@@ -26,7 +26,7 @@ Next, you should use the Beaker CLI to run the same experiment from your local m
 
 For these steps to work, you must have completed [installing Beaker](install.md). When installed:
 
-1. From the existing [MNIST example](https://beaker.org/ex/ex_zvtqxr5dlpqe) experiment page on Beaker.org, click the **Spec** tab.
+1. From the existing [MNIST example](https://beaker.org/ex/ex_z550sk9sz1ob) experiment page on Beaker.org, click the **Spec** tab.
 
 ![Spec for MNIST example](../images/ex_spec.png)
 
@@ -35,7 +35,7 @@ For these steps to work, you must have completed [installing Beaker](install.md)
 3. From the command line at this directory, enter:
 
 ```bash
-beaker experiment create -f ex_zvtqxr5dlpqe.yaml
+beaker experiment create -f ex_z550sk9sz1ob.yaml
 ```
 
 Make sure the experiment ID matches the specific experiment you want to re-run, exactly. This ID is unique to every experiment run.
@@ -43,10 +43,10 @@ Make sure the experiment ID matches the specific experiment you want to re-run, 
 You should see the following output:
 
 ```bash
-Experiment ex_zvtqxr5dlpqe submitted. See progress at https://beaker.org/ex/ex_zvtqxr5dlpqe
+Experiment ex_z550sk9sz1ob submitted. See progress at https://beaker.org/ex/ex_z550sk9sz1ob
 ```
 
-You can see your experiments tasks progress to completion at the URL provided by this output (for example, [https://beaker.org/ex/ex_zvtqxr5dlpqe](https://beaker.org/ex/ex_zvtqxr5dlpqe)).
+You can see your experiments tasks progress to completion at the URL provided by this output (for example, [https://beaker.org/ex/ex_z550sk9sz1ob](https://beaker.org/ex/ex_z550sk9sz1ob)).
 
 That's how an experiment is defined and shared by its spec, the YAML file containing the necessary metadata with which you can manage an experiment.
 


### PR DESCRIPTION
The previous example would never run because it refers to a cluster that has been decommissioned.