### PR TITLE
Remove references to experiment run

### DIFF
--- a/docs/concept/datasets.md
+++ b/docs/concept/datasets.md
@@ -128,12 +128,23 @@ as a Beaker experiment. The code for this experiment's image can be found
 [here](../examples/list-files).
 
 ```bash
-beaker experiment run \
-    --image example/list-files \
-    --env LIST_DIR=/data \
-    --source my-file-dataset:/data/single \
-    --source my-dir-dataset:/data/multi \
-    --result-path /results
+cat > find.yaml << EOF
+tasks:
+- name: list-files
+  spec:
+    image: examples/list-files
+    resultPath: /results
+    env:
+      LIST_DIR: /data
+    datasetMounts:
+    - datasetId: my-file-dataset
+      containerPath: /data/single
+    - datasetId: my-dir-dataset
+      containerPath: /data/single
+EOF
+```
+```
+beaker experiment create -f find.yaml
 ```
 
 This command will print a URL to your experiment, which should complete momentarily. Observe the

--- a/docs/example/wordcount.md
+++ b/docs/example/wordcount.md
@@ -2,14 +2,15 @@
 
 First, create an account at [beaker.org](https://beaker.org) and follow the instructions in your [account settings](https://beaker.org/user). See [Install](../first/install.md) for more options.
 
-Reach out to a Beaker admin (#beaker-users or bunsen@allenai.org) to get "Scientist" credentials in order to get authorization to create experiments.
+The following example [counts words](https://beaker.org/im/im_qbjvcda1sed7) in the text of [Moby Dick](https://beaker.org/ds/ds_1hz9k6sgxi0a).
 
-The following example [counts words](https://beaker.org/bp/im_qbjvcda1sed7) in the text of [Moby Dick](https://beaker.org/ds/ds_1hz9k6sgxi0a).
-
-```bash
-beaker experiment run \
-  --name wordcount-moby \
-  --image examples/wordcount \
-  --source examples/moby:/input \
-  --result-path /output
+```yaml
+tasks:
+- name: count-words
+  spec:
+    image: examples/wordcount
+    resultPath: /output
+    datasetMounts:
+    - datasetId: examples/moby
+      containerPath: /input
 ```

--- a/docs/start/spec.md
+++ b/docs/start/spec.md
@@ -4,18 +4,87 @@ In this example, you'll run your experiment using your image from the CLI and al
 
 You'll use your existing image and dataset, as defined in the [prior example](image.md). So, complete that step first if needed.
 
-# From the Command Line
+## Spec Format
 
-Enter the following from your Terminal shell, using the This example assumes you've successfully completed [Beaker and Docker installation](install.md), and you've set up your [Beaker.org](https://www.beaker.org) account so that you can run experiments as shown in [Your First Experiment](experiment.md).
+Experiment specs are written in YAML or JSON. For brevity, we'll use YAML throughout documentation.  The following example outlines most features of the current experiment spec.
 
-https://beaker.org/ex/ex_lhqimp6vaffk
+```yaml
+tasks:
+- name: my-first-task
+
+  # (required) Cluster sets where the task should run.
+  # See 'beaker cluster create'
+  cluster: ai2/my-cluster
+
+  # Spec describes the specifics of a process to run.
+  spec:
+    # (required) The code to run.
+    image: myaccount/myimage
+
+    # (required) Where results will be placed.
+    # Beaker automatically uploads files as the job runs.
+    resultPath: /path/to/results
+
+    # (optional) Override the default command in the image.
+    args: ['python', '-u', '/code/run.py']
+
+    # (optional) Environment variables as a key/value map.
+    env:
+      A_NUMBER: '0.5'
+      A_STRING: foobar
+      # ...
+
+    # (optional) Mount datasets as directories into the task.
+    datasetMounts:
+      - datasetId: training-files
+        containerPath: /traindata
+
+      # Mount '/foo.yaml' from a config dataset to '/path/to/config.yml'.
+      # The subPath field mounts files or subdirectories within a dataset.
+      - datasetId: config-dataset 
+        subPath: foo.yaml
+        containerPath: /path/to/config.yml
+
+    # (optional) Set minimum resource requirements for larger tasks.
+    # All fields are optional, and any number can be set.
+    requirements:
+      memory: '7.5GiB' # number followed by unit suffix
+      cpuCount: 1.5    # number of logical cores
+      gpuCount: 2      # must be an integer
+
+- name: my-second-task
+  spec:
+    # ...
+
+  # (optional) Set dependencies between tasks.
+  dependsOn:
+    # (required) Name the task to depend on.
+    parentName: my-first-task
+
+    # (optional) If set, mount the result of that task to the following directory.
+    containerPath: /path/to/input
+```
+
+## From the Command Line
+
+To run an experiment, first write a spec file.  For example, the following runs the classic mnist machine learning task.
+
+```yaml
+tasks:
+- spec:
+    image: mymnist
+    resultPath: /output
+    env:
+      EPOCH: '50'
+    datasetMounts:
+    - datasetId: mymnist-dataset
+      containerPath: /data
+```
+
+Experiments can be run with `beaker experiment create`.
 
 ```
-$ beaker experiment run \
-    --image mymnist \
-    --env EPOCH=50 \
-    --source mymnist-dataset:/data \
-    --result-path /output
+$ beaker experiment create -f mnist.yaml
 
 Experiment ex_lhqimp6vaffk submitted. See progress at https://beaker.org/ex/ex_lhqimp6vaffk
 ```

--- a/docs/start/spec.md
+++ b/docs/start/spec.md
@@ -58,11 +58,11 @@ tasks:
 
   # (optional) Set dependencies between tasks.
   dependsOn:
-    # (required) Name the task to depend on.
-    parentName: my-first-task
+      # (required) Name the task to depend on.
+    - parentName: my-first-task
 
-    # (optional) If set, mount the result of that task to the following directory.
-    containerPath: /path/to/input
+      # (optional) If set, mount the result of that task to the following directory.
+      containerPath: /path/to/input
 ```
 
 ## From the Command Line

--- a/examples/wordcount/README.md
+++ b/examples/wordcount/README.md
@@ -25,9 +25,15 @@ Results are placed in `/output`
 
 ## Example usage
 
-```bash
-beaker experiment run \
-  --image wordcount \
-  --source examples/moby:/input \
-  --result-path /output
+Run the following experiment with `beaker experiment create`.
+
+```yaml
+tasks:
+- name: count-words
+  spec:
+    image: mywordcount
+    resultPath: /output
+    datasetMounts:
+    - datasetId: examples/moby
+      containerPath: /input
 ```


### PR DESCRIPTION
This change also fixes some broken links and introduces missing spec documentation.  The spec file in particular was pretty jumbled/incoherent.