### PR TITLE
Remove deprecated -f flag in beaker experiment create

### DIFF
--- a/docs/start/experiment.md
+++ b/docs/start/experiment.md
@@ -19,7 +19,7 @@ For these instructions to work, you must have completed [installing Beaker](inst
 3. From the command line at this directory, enter:
 
    ```bash
-   beaker experiment create -f experiment.yaml
+   beaker experiment create experiment.yaml
    ```
 
 You should see the following output:


### PR DESCRIPTION
It looks like providing `-f` in `beaker experiment create` is now an error:

```
$ beaker experiment create -f experiment.yaml
Error: unknown shorthand flag: 'f' in -f
```

When I remove `-f` the command runs fine.

```
$ beaker experiment create experiment.yaml
Experiment XXX submitted. See progress at https://beaker.org/ex/XXX
```

Version: Beaker 1.0.19